### PR TITLE
Fix regex for new GitHub output of pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.0.2 / 2017-03-06:
+
+- Added the "from" key
+
 v1.0.1 / 2012-01-31:
 
 - Remove branch tags from log output (not that useful in github's wiki context)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v1.0.3 / 2022-01-29:
+
+- GitHub output has changed, therefor regex syntax has to be corrected
+  + Request repo link from git remote, it is no longer in pullResult
+  + pullResult answer is now 'Updating FROMSHA..TO__SHA'
+  + also pullResult answer is localized!
+
 v1.0.2 / 2017-03-06:
 
 - Added the "from" key

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get a checkout of your Github repo:
 	
 Then create a cron (e.g. `crontab -e`):
 
-	*/15 * * * * github-wiki-notify.php --path="/some/path/repo.wiki" --email="list@example.com" --subject="Wiki updated!"
+	*/15 * * * * github-wiki-notify.php --path="/some/path/repo.wiki" --email="list@example.com" --subject="Wiki updated!" --from="from@example.org"
 
 Problems? Want to contribute?
 -----------------------------

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -31,7 +31,7 @@ foreach ($argv as $arg)
 	} else if (preg_match('/--subject=(.*)/', $arg, $match)) {
 		$subject = $match[1];
 	} else if (preg_match('/--from=(.*)/', $arg, $match)) {
-		$subject = $match[1];
+		$from = $match[1];
 	}
 }
 

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -21,6 +21,7 @@
 $path = null;
 $email = null;
 $subject = null;
+$from = null;
 foreach ($argv as $arg)
 {
 	if (preg_match('/--path=(.*)/', $arg, $match)) {
@@ -29,13 +30,15 @@ foreach ($argv as $arg)
 		$email = $match[1];
 	} else if (preg_match('/--subject=(.*)/', $arg, $match)) {
 		$subject = $match[1];
+	} else if (preg_match('/--from=(.*)/', $arg, $match)) {
+		$subject = $match[1];
 	}
 }
 
-if (is_null($path) || is_null($email))
+if (is_null($path) || is_null($email) || is_null($from))
 {
 	echo("Usage:\n");
-	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com\n");
+	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com --from=my@email.com\n");
 	exit(1);
 }
 
@@ -56,6 +59,6 @@ if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
 		$subject = '[SCM]: ' . $repo . ' was updated';
 	}
 	$body = "To see the changes, visit:\n" . $wikiDiffUrl . "\n\nChangelog:\n" . $changeLog . "\n";
-	mail($email, $subject, $body, "From: $email");
+	mail($email, $subject, $body, "From: $from");
 }
 // else no updates

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -47,12 +47,19 @@ if (!chdir($path)) {
 	exit(2);
 }
 
-$pullResult = `git pull 2>&1`;
-if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
+// request repo-URL from git remote
+$remote = `git remote -v`;
+$repo = 'unknown';
+if (preg_match('/origin\s*(\S*)\s*\(fetch\)\n/', $remote, $match))
 {
-	$repo = $match[1];
-	$revs = $match[2];
-	$wikiDiffUrl = 'https://github.com/' . str_replace('.wiki', '/wiki', $repo) . '/_compare/' . $revs;
+    $repo = $match[1];
+}
+
+$pullResult = `git pull 2>&1`;
+if (preg_match('/^\S* ([a-z0-9]{7}\.\.[a-z0-9]{7})\n/', $pullResult, $match))
+{
+	$revs = $match[1];
+	$wikiDiffUrl = str_replace('.wiki.git', '/wiki', $repo) . '/_compare/' . $revs;
 	$changeLog = `git log --pretty=format:'%h - %s (%cr) <%an>' $revs`;
 	
 	if (is_null($subject)) {
@@ -62,3 +69,4 @@ if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
 	mail($email, $subject, $body, "From: $from");
 }
 // else no updates
+


### PR DESCRIPTION
Just found this little, very helpful script, but it was not working anymore.
Seems output from `git pull` has changed, so the regex patterns needed some revamp.
It turned out, that the output is even localized, thus the pullResult pattern is very basic, but I think it is safe enough to detect changes.

I also pulled improvement from https://github.com/ilyasergey/github-wiki-notify.

Updated the CHANGELOG and README too.