### PR TITLE
Fix for localized git pull output

### DIFF
--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -12,8 +12,9 @@
  *     --verbose=LEVEL				LEVEL = 0..5, see class Level, 0 = quiet .. 5 = debugging, default = 0
  *
  * @author Anthony Bush
- * @version 1.0.1
+ * @version 1.0.2
  * @copyright Anthony Bush, 20 December, 2011
+ * @copyright Armin Stebich, 25 June, 2022
  * @license <http://www.opensource.org/licenses/bsd-license.php>
  * @package default
  **/

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -71,7 +71,7 @@ if (!chdir($path)) {
 	exit(2);
 }
 
-$pullResult = `git pull 2>&1`;
+$pullResult = `git pull -v 2>&1`;
 if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
 {
 	$repo = $match[1];

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -8,7 +8,8 @@
  *     github-wiki-notify.php --path=/path/to/repo --email=list@example.com --subject="Wiki updated!"
  * 
  * Optional parameter:
- *     --verbose=LEVEL		LEVEL = 0..5, see class Level, 0 = quiet .. 5 = debugging, default = 0
+ *     --from=sender@example.com	sender email address, otherwise the --email address is used
+ *     --verbose=LEVEL				LEVEL = 0..5, see class Level, 0 = quiet .. 5 = debugging, default = 0
  *
  * @author Anthony Bush
  * @version 1.0.1
@@ -35,6 +36,7 @@ class Level {
 
 $path = null;
 $email = null;
+$from = null;
 $subject = null;
 $verbose = Level::NOTHING;
 foreach ($argv as $arg)
@@ -43,6 +45,8 @@ foreach ($argv as $arg)
 		$path = $match[1];
 	} else if (preg_match('/--email=(.*)/', $arg, $match)) {
 		$email = $match[1];
+	} else if (preg_match('/--from=(.*)/', $arg, $match)) {
+		$from = $match[1];
 	} else if (preg_match('/--subject=(.*)/', $arg, $match)) {
 		$subject = $match[1];
 	} else if (preg_match('/--verbose=(.*)/', $arg, $match)) {
@@ -53,8 +57,13 @@ foreach ($argv as $arg)
 if (is_null($path) || is_null($email))
 {
 	echo("Usage:\n");
-	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com [--verbose=(0..5)]\n");
+	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com [--from=sender@example.com] [--verbose=(0..5)]\n");
 	exit(1);
+}
+
+if (is_null($from))
+{
+	$from = $email;
 }
 
 if (!chdir($path)) {
@@ -74,7 +83,7 @@ if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
 		$subject = '[SCM]: ' . $repo . ' was updated';
 	}
 	$body = "To see the changes, visit:\n" . $wikiDiffUrl . "\n\nChangelog:\n" . $changeLog . "\n";
-	mail($email, $subject, $body, "From: $email");
+	mail($email, $subject, $body, "From: $from");
 }
 else {
 	verbose( "No match in pullResult!", Level::INFO);

--- a/github-wiki-notify.php
+++ b/github-wiki-notify.php
@@ -6,6 +6,9 @@
  * Usage is simple, just cron it:
  * 
  *     github-wiki-notify.php --path=/path/to/repo --email=list@example.com --subject="Wiki updated!"
+ * 
+ * Optional parameter:
+ *     --verbose=LEVEL		LEVEL = 0..5, see class Level, 0 = quiet .. 5 = debugging, default = 0
  *
  * @author Anthony Bush
  * @version 1.0.1
@@ -15,12 +18,25 @@
  **/
 
 /**
+ * verbose level
+ **/
+class Level {
+	const NOTHING = 0;
+	const ALERT   = 1;
+	const ERROR   = 2;
+	const WARNING = 3;
+	const INFO    = 4;
+	const DEBUG   = 5;
+}
+
+/**
  * Define DocBlock
  **/
 
 $path = null;
 $email = null;
 $subject = null;
+$verbose = Level::NOTHING;
 foreach ($argv as $arg)
 {
 	if (preg_match('/--path=(.*)/', $arg, $match)) {
@@ -29,13 +45,15 @@ foreach ($argv as $arg)
 		$email = $match[1];
 	} else if (preg_match('/--subject=(.*)/', $arg, $match)) {
 		$subject = $match[1];
+	} else if (preg_match('/--verbose=(.*)/', $arg, $match)) {
+		$verbose = $match[1];
 	}
 }
 
 if (is_null($path) || is_null($email))
 {
 	echo("Usage:\n");
-	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com\n");
+	echo("  " . basename(__FILE__) . " --path=/path/to/repo --email=list@example.com [--verbose=(0..5)]\n");
 	exit(1);
 }
 
@@ -58,4 +76,17 @@ if (preg_match('/From github\.com:(.*)\n\s*([^\s]+)/', $pullResult, $match))
 	$body = "To see the changes, visit:\n" . $wikiDiffUrl . "\n\nChangelog:\n" . $changeLog . "\n";
 	mail($email, $subject, $body, "From: $email");
 }
-// else no updates
+else {
+	verbose( "No match in pullResult!", Level::INFO);
+	verbose( "\npullResult:");
+	verbose( $pullResult);
+}
+
+function verbose($message, $level = Level::DEBUG)
+{
+	global $verbose;
+
+	if ($verbose >= $level) {
+		echo $message . "\n";
+	}
+}


### PR DESCRIPTION
Finally I finished this 2nd shot.
I think I addressed all issues from #2.
The regex for repo and revs was still not usable because of localized git output.
So I used `git remote` for the repo and my #2 regex for the revs.
I set version to 1.0.2, because both added parameters are optional.
The verbose output was vital to check the regex and program flow, so I kept it for further improvement. The default verbose behavior is to be quiet to be compatible with previous version.
I tested both successfully, HTTPS and SSH clones.